### PR TITLE
a (hacky) way to fix MSAA FFR and optimize MSAA for quest for GLES2

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -3228,6 +3228,11 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 
 	} else {
 		state.render_no_shadows = false;
+#ifdef ANDROID_ENABLED // NeoSpark314: this is a hack for oculus quest
+		if (storage->frame.current_rt->external.fbo != 0) { 
+			current_fb = storage->frame.current_rt->external.fbo;
+		} else
+#endif
 		if (storage->frame.current_rt->multisample_active) {
 			current_fb = storage->frame.current_rt->multisample_fbo;
 		} else if (storage->frame.current_rt->external.fbo != 0) {
@@ -3235,6 +3240,7 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 		} else {
 			current_fb = storage->frame.current_rt->fbo;
 		}
+
 		env = environment_owner.getornull(p_environment);
 
 		viewport_width = storage->frame.current_rt->width;
@@ -3495,9 +3501,10 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 			glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 			glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 #elif ANDROID_ENABLED
-
+		if (storage->frame.current_rt->external.fbo == 0) { // NeoSpark314: this is a hack for oculus quest
 			// In GLES2 AndroidBlit is not available, so just copy color texture manually
 			_copy_texture_to_buffer(storage->frame.current_rt->multisample_color, storage->frame.current_rt->fbo);
+		}
 #endif
 		}
 
@@ -3524,7 +3531,9 @@ void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const 
 	}
 
 	//post process
-	_post_process(env, p_cam_projection);
+	if (storage->frame.current_rt->external.fbo == 0) { // NeoSpark314: this is a hack for oculus quest
+		_post_process(env, p_cam_projection);
+	}
 
 	//#define GLES2_SHADOW_ATLAS_DEBUG_VIEW
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5156,14 +5156,24 @@ void RasterizerStorageGLES2::render_target_set_external_texture(RID p_render_tar
 
 		// is there a point to setting the internal formats? we don't know them..
 
-		// set our texture as the destination for our framebuffer
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, p_texture_id, 0);
+#ifdef ANDROID_ENABLED // NeoSpark314: this is a hack for oculus quest
+		if (rt->multisample_active) {
+			static const int msaa_value[] = { 0, 2, 4, 8, 16 };
+			int msaa = msaa_value[rt->msaa];
+			glFramebufferTexture2DMultisample(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, p_texture_id, 0, msaa);
+			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->multisample_depth);
+		} else 
+#endif
+		{
+			// set our texture as the destination for our framebuffer
+			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, p_texture_id, 0);
 
-		// seeing we're rendering into this directly, better also use our depth buffer, just use our existing one :)
-		if (config.support_depth_texture) {
-			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
-		} else {
-			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->depth);
+			// seeing we're rendering into this directly, better also use our depth buffer, just use our existing one :)
+			if (config.support_depth_texture) {
+				glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
+			} else {
+				glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->depth);
+			}
 		}
 
 		// check status and unbind


### PR DESCRIPTION
This change avoids any post processing in the case an external texture
is used and it also renders directly to the provided external texture.
This addresses https://github.com/GodotVR/godot_oculus_mobile/issues/70
and ignores the changes in https://github.com/godotengine/godot/pull/33444
for the android case.